### PR TITLE
[racl_ctrl] Fix alert order to align with hjson specification

### DIFF
--- a/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
+++ b/hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl
@@ -73,10 +73,10 @@ module ${module_instance_name} import ${module_instance_name}_reg_pkg::*; #(
   logic [NumAlerts-1:0] alert_test, alert;
 
 % if enable_shadow_reg:
-  localparam logic [NumAlerts-1:0] IsFatal = {1'b1, 1'b0};
+  localparam logic [NumAlerts-1:0] IsFatal = {1'b0, 1'b1};
 
-  assign alert[0]  = shadowed_update_err;
-  assign alert[1]  = reg_intg_error | shadowed_storage_err;
+  assign alert[0]  = reg_intg_error | shadowed_storage_err;
+  assign alert[1]  = shadowed_update_err;
 
   assign alert_test[0] = reg2hw.alert_test.fatal_fault.q & reg2hw.alert_test.fatal_fault.qe;
   assign alert_test[1] = reg2hw.alert_test.recov_ctrl_update_err.q &

--- a/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
+++ b/hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv
@@ -62,10 +62,10 @@ module racl_ctrl import racl_ctrl_reg_pkg::*; #(
   //////////////////////////////////////////////////////////////////////////////////////////////////
   logic [NumAlerts-1:0] alert_test, alert;
 
-  localparam logic [NumAlerts-1:0] IsFatal = {1'b1, 1'b0};
+  localparam logic [NumAlerts-1:0] IsFatal = {1'b0, 1'b1};
 
-  assign alert[0]  = shadowed_update_err;
-  assign alert[1]  = reg_intg_error | shadowed_storage_err;
+  assign alert[0]  = reg_intg_error | shadowed_storage_err;
+  assign alert[1]  = shadowed_update_err;
 
   assign alert_test[0] = reg2hw.alert_test.fatal_fault.q & reg2hw.alert_test.fatal_fault.qe;
   assign alert_test[1] = reg2hw.alert_test.recov_ctrl_update_err.q &


### PR DESCRIPTION
## Problem

The alert order in racl_ctrl has been mixed up. Issue #27390 has only partially corrected it (merge commit 3023870 fixed soc_dbg_ctrl but not racl_ctrl).

In racl_ctrl.hjson, the alerts are specified as:
```
[0] fatal_fault (isFatal=1)
[1] recov_ctrl_update_err (isFatal=0)
```

However, the RTL implementation had the alerts swapped:
- `alert[0]` was assigned to `shadowed_update_err` (recoverable condition)
- `alert[1]` was assigned to `reg_intg_error | shadowed_storage_err` (fatal condition)  
- `IsFatal = {1'b1, 1'b0}` meant alert[1] was fatal and alert[0] was recoverable

This misalignment between the hjson specification and RTL implementation could cause confusion and incorrect alert handling.

## Solution

This PR fixes the alert order to align with the hjson specification:

- `alert[0] = reg_intg_error | shadowed_storage_err` (fatal condition)
- `alert[1] = shadowed_update_err` (recoverable condition)
- `IsFatal = {1'b0, 1'b1}` (alert[0] fatal, alert[1] recoverable)

The `alert_test` assignments remain correct as they already mapped to the right register bits in the ALERT_TEST register.

## Files Changed

- `hw/ip_templates/racl_ctrl/rtl/racl_ctrl.sv.tpl` - Fixed template
- `hw/top_darjeeling/ip_autogen/racl_ctrl/rtl/racl_ctrl.sv` - Fixed generated instance

## Testing

The fix ensures that:
1. Alert[0] (fatal_fault) is triggered by fatal conditions and marked as fatal
2. Alert[1] (recov_ctrl_update_err) is triggered by recoverable conditions and marked as recoverable  
3. The ALERT_TEST register bits correctly map to their respective alerts

This aligns the RTL implementation with the hjson specification and the alert_test register layout.